### PR TITLE
Add dynamic CV page with LaTeX conversion and brand integration

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,3 +3,4 @@ https://www.nytimes.com/2023/12/22/podcasts/hard-fork-predictions-jenny-slate.ht
 https://www.reddit.com/r/socialmedia/comments/1is1cmc/is_linkedin_turning_into_the_new_facebook/
 https://www.linkedin.com/in/emily-gorcenski-0a3830200/
 https://worksonmymachine.substack.com/p/the-coming-knowledge-work-supply
+https://github.com/oscar-barlow/CV/releases/latest/download/CV.pdf

--- a/frontend/styles/index.css
+++ b/frontend/styles/index.css
@@ -1034,3 +1034,251 @@ hr {
     padding: 1.5rem 1rem;
   }
 }
+
+/* CV Page Styles */
+.cv-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 0;
+}
+
+.cv-loading {
+  text-align: center;
+  padding: 4rem 2rem;
+}
+
+.loading-brand-mark {
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem auto;
+}
+
+.loading-brand-mark .brand-shape {
+  width: 40px;
+  height: 40px;
+  background: linear-gradient(135deg, var(--tertiary-color), var(--action-color));
+  border-radius: 8px;
+  position: relative;
+  animation: brandPulse 2s ease-in-out infinite;
+}
+
+.loading-brand-mark .brand-shape::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 12px;
+  height: 12px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 50%;
+}
+
+@keyframes brandPulse {
+  0%, 100% { 
+    transform: rotate(0deg) scale(1);
+    opacity: 0.8;
+  }
+  50% { 
+    transform: rotate(45deg) scale(1.1);
+    opacity: 1;
+  }
+}
+
+.cv-error {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: var(--muted-text);
+}
+
+.cv-error h2 {
+  color: var(--heading-color);
+  margin-bottom: 1rem;
+}
+
+.cv-error a {
+  color: var(--action-color);
+  font-weight: 500;
+}
+
+.cv-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.cv-separator {
+  display: flex;
+  justify-content: center;
+  margin: 2rem 0;
+  opacity: 0.6;
+}
+
+.cv-footer {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--subtle-border);
+}
+
+.cv-signature {
+  display: flex;
+  justify-content: center;
+  opacity: 0.6;
+}
+
+.cv-title {
+  font-size: 3rem;
+  font-weight: 700;
+  color: var(--heading-color);
+  margin: 0 0 1rem 0;
+  letter-spacing: -0.02em;
+}
+
+.cv-subtitle {
+  font-size: 1.2rem;
+  color: var(--muted-text);
+  margin: 0;
+  font-weight: 500;
+}
+
+.cv-email {
+  font-size: 1.1rem;
+  margin: 1rem 0 0 0;
+}
+
+.cv-email a {
+  color: var(--action-color);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.cv-email a:hover {
+  color: var(--action-color-secondary);
+  text-decoration: underline;
+}
+
+.cv-download {
+  font-size: 0.9rem;
+  margin: 0.5rem 0;
+}
+
+.cv-pdf-link {
+  color: var(--muted-text);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+  border-bottom: 1px solid transparent;
+}
+
+.cv-pdf-link:hover {
+  color: var(--action-color);
+  border-bottom-color: var(--action-color);
+}
+
+.cv-body {
+  line-height: 1.7;
+  font-size: 1.1rem;
+}
+
+.cv-section-title {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--heading-color);
+  margin: 3rem 0 1.5rem 0;
+  position: relative;
+  padding-bottom: 0.5rem;
+}
+
+.cv-section-title::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 50px;
+  height: 3px;
+  background: var(--tertiary-color);
+  border-radius: 2px;
+}
+
+.cv-subsection-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--heading-color);
+  margin: 2rem 0 1rem 0;
+}
+
+.cv-list {
+  margin: 1.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.cv-list li {
+  margin-bottom: 0.75rem;
+  line-height: 1.6;
+  position: relative;
+}
+
+.cv-list li::marker {
+  color: var(--tertiary-color);
+}
+
+.cv-body p {
+  margin-bottom: 1.5rem;
+  line-height: 1.7;
+}
+
+.cv-body strong {
+  color: var(--heading-color);
+  font-weight: 600;
+}
+
+.cv-body em {
+  color: var(--action-color);
+  font-style: normal;
+  font-weight: 500;
+}
+
+/* Responsive CV styles */
+@media (max-width: 768px) {
+  .cv-container {
+    padding: 1rem 0;
+  }
+  
+  .cv-title {
+    font-size: 2.5rem;
+  }
+  
+  .cv-subtitle {
+    font-size: 1.1rem;
+  }
+  
+  .cv-section-title {
+    font-size: 1.7rem;
+    margin: 2.5rem 0 1rem 0;
+  }
+  
+  .cv-subsection-title {
+    font-size: 1.3rem;
+  }
+  
+  .cv-body {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .cv-title {
+    font-size: 2rem;
+  }
+  
+  .cv-section-title {
+    font-size: 1.5rem;
+  }
+  
+  .cv-list {
+    padding-left: 1rem;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "npm": ">=10.0.0"
   },
   "dependencies": {
-    "strip-ansi": "^7.1.0",
-    "string-width": "^7.2.0"
+    "string-width": "^7.2.0",
+    "strip-ansi": "^7.1.0"
   },
   "devDependencies": {
     "esbuild": "^0.25.8",

--- a/src/_components/navbar.liquid
+++ b/src/_components/navbar.liquid
@@ -4,6 +4,6 @@
   </a>
   <ul class="nav-links">
     <li><a href="{{ '/posts' | relative_url }}">Writing</a></li>
-    <li><a href="https://github.com/oscar-barlow/CV/releases/latest" class="cv-link">CV</a></li>
+    <li><a href="{{ '/cv' | relative_url }}" class="cv-link">CV</a></li>
   </ul>
 </nav>

--- a/src/cv.md
+++ b/src/cv.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: "Curriculum Vitae"
-description: "Professional experience and qualifications of Oscar Barlow, innovative technology leader specializing in AI, data engineering, and inclusive team building."
 ---
 
 <div class="cv-container">

--- a/src/cv.md
+++ b/src/cv.md
@@ -1,0 +1,263 @@
+---
+layout: page
+title: "Curriculum Vitae"
+description: "Professional experience and qualifications of Oscar Barlow, innovative technology leader specializing in AI, data engineering, and inclusive team building."
+---
+
+<div class="cv-container">
+  <div id="cv-loading" class="cv-loading">
+    <div class="loading-brand-mark">
+      <div class="brand-shape"></div>
+    </div>
+    <p>Loading...</p>
+  </div>
+  
+  <div id="cv-error" class="cv-error" style="display: none;">
+    <h2>Unable to Load CV</h2>
+    <p>There was an issue fetching the latest CV. You can view it directly on <a href="https://github.com/oscar-barlow/CV/releases/latest">GitHub</a>.</p>
+  </div>
+  
+  <div id="cv-fallback" class="cv-fallback" style="display: none;">
+    <header class="cv-header">
+      <h1 class="cv-title">Oscar Barlow</h1>
+      <p class="cv-email"><a href="mailto:hi@oscarbarlow.com">hi@oscarbarlow.com</a></p>
+      <p class="cv-subtitle">Curriculum Vitae</p>
+      <p class="cv-download">
+        <a href="https://github.com/oscar-barlow/CV/releases/latest/download/CV.pdf" target="_blank" class="cv-pdf-link">
+          PDF ↓
+        </a>
+      </p>
+    </header>
+    <div class="cv-separator">
+      <div class="brand-shape-tiny"></div>
+    </div>
+    <div class="cv-body">
+      <p>Unable to load the latest CV content dynamically. You can:</p>
+      <ul>
+        <li><a href="https://github.com/oscar-barlow/CV/releases/latest/download/CV.pdf" target="_blank">Download the PDF version</a></li>
+        <li><a href="https://github.com/oscar-barlow/CV" target="_blank">View the source on GitHub</a></li>
+      </ul>
+    </div>
+  </div>
+  
+  <noscript>
+    <div class="cv-fallback">
+      <header class="cv-header">
+        <h1 class="cv-title">Oscar Barlow</h1>
+        <p class="cv-email"><a href="mailto:hi@oscarbarlow.com">hi@oscarbarlow.com</a></p>
+        <p class="cv-subtitle">Curriculum Vitae</p>
+        <p class="cv-download">
+          <a href="https://github.com/oscar-barlow/CV/releases/latest/download/CV.pdf" target="_blank" class="cv-pdf-link">
+            PDF ↓
+          </a>
+        </p>
+      </header>
+      <div class="cv-separator">
+        <div class="brand-shape-tiny"></div>
+      </div>
+      <div class="cv-body">
+        <p>JavaScript is required to load the latest CV content. You can:</p>
+        <ul>
+          <li><a href="https://github.com/oscar-barlow/CV/releases/latest/download/CV.pdf" target="_blank">Download the PDF version</a></li>
+          <li><a href="https://github.com/oscar-barlow/CV" target="_blank">View the source on GitHub</a></li>
+        </ul>
+      </div>
+    </div>
+  </noscript>
+  
+  <div id="cv-content" class="cv-content" style="display: none;">
+    <!-- CV content will be dynamically inserted here -->
+  </div>
+</div>
+
+<script>
+class CVLoader {
+  constructor() {
+    this.cache = null;
+    this.cacheTime = null;
+    this.cacheDuration = 5 * 60 * 1000; // 5 minutes
+  }
+
+  async fetchCV() {
+    const loadingEl = document.getElementById('cv-loading');
+    const errorEl = document.getElementById('cv-error');
+    const contentEl = document.getElementById('cv-content');
+
+    try {
+      // Check cache first
+      if (this.cache && this.cacheTime && (Date.now() - this.cacheTime < this.cacheDuration)) {
+        this.displayCV(this.cache.htmlContent, this.cache.title, this.cache.email);
+        return;
+      }
+
+      // Fetch LaTeX file from GitHub
+      const response = await fetch('https://raw.githubusercontent.com/oscar-barlow/CV/master/CV.tex');
+      
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      
+      const latexContent = await response.text();
+      
+      // Convert LaTeX to HTML using simplified parser
+      const { htmlContent, title, email } = this.convertLatex(latexContent);
+      
+      // Cache the result
+      this.cache = { htmlContent, title, email };
+      this.cacheTime = Date.now();
+      
+      this.displayCV(htmlContent, title, email);
+      
+    } catch (error) {
+      console.error('Error loading CV:', error);
+      const fallbackEl = document.getElementById('cv-fallback');
+      loadingEl.style.display = 'none';
+      
+      // Show fallback with download links instead of just error message
+      if (fallbackEl) {
+        fallbackEl.style.display = 'block';
+      } else {
+        errorEl.style.display = 'block';
+      }
+    }
+  }
+
+  convertLatex(latexContent) {
+    let content = latexContent;
+    
+    // Extract important information before removing commands
+    const titleMatch = content.match(/\\title\{([^}]*)\}/);
+    const emailMatch = content.match(/\\cvsubtitle\{([^}]*)\}/);
+    const title = titleMatch ? titleMatch[1] : 'Oscar Barlow';
+    const email = emailMatch ? emailMatch[1] : '';
+    
+    // Remove LaTeX document structure and commands
+    content = content.replace(/\\documentclass(\[[^\]]*\])?\{[^}]*\}/g, '');
+    content = content.replace(/\\usepackage(\[[^\]]*\])?\{[^}]*\}/g, '');
+    content = content.replace(/\\begin\{document\}/g, '');
+    content = content.replace(/\\end\{document\}/g, '');
+    content = content.replace(/\\author\{[^}]*\}/g, '');
+    content = content.replace(/\\date\{[^}]*\}/g, '');
+    content = content.replace(/\\title\{[^}]*\}/g, '');
+    content = content.replace(/\\maketitle/g, '');
+    content = content.replace(/\\cvsubtitle\{[^}]*\}/g, '');
+    content = content.replace(/\\pagestyle\{[^}]*\}/g, '');
+    content = content.replace(/\\setlength\{[^}]*\}\{[^}]*\}/g, '');
+    
+    // Remove LaTeX comments and scope markers
+    content = content.replace(/%.*$/gm, '');
+    content = content.replace(/\{\s*%\s*Start of local scope/g, '');
+    content = content.replace(/\}\s*%\s*End of local scope/g, '');
+    content = content.replace(/^\s*\{\s*$/gm, '');
+    content = content.replace(/^\s*\}\s*$/gm, '');
+    
+    // Convert sections and subsections
+    content = content.replace(/\\section\*?\{([^}]*)\}/g, '<h2 class="cv-section-title">$1</h2>');
+    content = content.replace(/\\subsection\*?\{([^}]*)\}/g, '<h3 class="cv-subsection-title">$1</h3>');
+    
+    // Convert lists
+    content = content.replace(/\\begin\{itemize\}/g, '<ul class="cv-list">');
+    content = content.replace(/\\end\{itemize\}/g, '</ul>');
+    content = content.replace(/\\item\s*/g, '<li>');
+    
+    // Convert text formatting
+    content = content.replace(/\\textbf\{([^}]*)\}/g, '<strong>$1</strong>');
+    content = content.replace(/\\emph\{([^}]*)\}/g, '<em>$1</em>');
+    content = content.replace(/\\textit\{([^}]*)\}/g, '<em>$1</em>');
+    
+    // Handle LaTeX character escaping
+    content = content.replace(/\\&/g, '&');  // LaTeX escaped ampersand
+    content = content.replace(/--/g, '–');   // Double dash to en dash
+    content = content.replace(/---/g, '—');  // Triple dash to em dash
+    
+    // Handle line breaks
+    content = content.replace(/\\\\/g, '<br>');
+    
+    // Clean up excessive whitespace
+    content = content.replace(/\s+/g, ' ');
+    content = content.replace(/\n\s*\n/g, '\n\n');
+    
+    // Split into paragraphs and wrap properly
+    const sections = content.split(/(?=<h[2-3])/);
+    let htmlContent = '';
+    
+    for (let section of sections) {
+      section = section.trim();
+      if (!section) continue;
+      
+      // Split section into parts: heading + content
+      const parts = section.split(/(<h[2-3][^>]*>.*?<\/h[2-3]>)/);
+      
+      for (let part of parts) {
+        part = part.trim();
+        if (!part) continue;
+        
+        if (part.match(/^<h[2-3]/)) {
+          htmlContent += part + '\n';
+        } else if (part.match(/^<ul/)) {
+          htmlContent += part + '\n';
+        } else {
+          // Regular content - wrap in paragraphs
+          const paragraphs = part.split(/\n\s*\n/).filter(p => p.trim());
+          for (let para of paragraphs) {
+            para = para.trim().replace(/\n/g, ' ');
+            if (para && !para.match(/^<[ul]/)) {
+              htmlContent += '<p>' + para + '</p>\n';
+            } else if (para.match(/^<[ul]/)) {
+              htmlContent += para + '\n';
+            }
+          }
+        }
+      }
+    }
+    
+    // Final cleanup
+    htmlContent = htmlContent.replace(/<p>\s*<\/p>/g, '');
+    htmlContent = htmlContent.replace(/<p>\s*(<[uh][1-6ul])/g, '$1');
+    htmlContent = htmlContent.replace(/(<\/[uh][1-6ul]>)\s*<\/p>/g, '$1');
+    
+    return { htmlContent, title, email };
+  }
+
+  displayCV(htmlContent, title = 'Oscar Barlow', email = '') {
+    const loadingEl = document.getElementById('cv-loading');
+    const contentEl = document.getElementById('cv-content');
+    
+    // Wrap content in proper structure
+    const wrappedContent = `
+      <header class="cv-header">
+        <h1 class="cv-title">${title}</h1>
+        ${email ? `<p class="cv-email"><a href="mailto:${email}">${email}</a></p>` : ''}
+        <p class="cv-subtitle">Curriculum Vitae</p>
+        <p class="cv-download">
+          <a href="https://github.com/oscar-barlow/CV/releases/latest/download/CV.pdf" target="_blank" class="cv-pdf-link">
+            PDF ↓
+          </a>
+        </p>
+      </header>
+      <div class="cv-separator">
+        <div class="brand-shape-tiny"></div>
+      </div>
+      <div class="cv-body">
+        ${htmlContent}
+      </div>
+      <footer class="cv-footer">
+        <div class="cv-signature">
+          <div class="brand-shape-tiny"></div>
+        </div>
+      </footer>
+    `;
+    
+    contentEl.innerHTML = wrappedContent;
+    loadingEl.style.display = 'none';
+    contentEl.style.display = 'block';
+  }
+}
+
+// Initialize CV loader when page loads
+document.addEventListener('DOMContentLoaded', () => {
+  const cvLoader = new CVLoader();
+  cvLoader.fetchCV();
+});
+</script>
+


### PR DESCRIPTION
- Create new CV page that fetches and converts LaTeX from GitHub repository
- Implement LaTeX to HTML parser with proper character escaping (ampersands, dashes)
- Add brand mark separators and signature matching posts page style
- Include subtle PDF download link with download glyph
- Update navbar to link to local CV page instead of external GitHub
- Add comprehensive fallback system for JavaScript failures and disabled JS
- Style with brand colors, typography, and responsive design
- Support email extraction and proper header hierarchy (name → email → title → PDF)
- Cache converted CV content for 5 minutes to reduce API calls

🤖 Generated with [Claude Code](https://claude.ai/code)