### PR TITLE
Add GitHub download link to CV loading screen

### DIFF
--- a/src/_layouts/CV.liquid
+++ b/src/_layouts/CV.liquid
@@ -14,6 +14,11 @@
               <div class="brand-shape"></div>
             </div>
             <p>Loading...</p>
+            <p class="cv-loading-link">
+              <a href="https://github.com/oscar-barlow/CV/releases/latest" target="_blank">
+                Download from GitHub
+              </a>
+            </p>
           </div>
           
           <div id="cv-error" class="cv-error" style="display: none;">


### PR DESCRIPTION
Provides users with immediate access to CV while page loads, improving fallback experience.

🤖 Generated with [Claude Code](https://claude.ai/code)