### PR TITLE
Add Buttondown email subscribe form to posts and Writing page

### DIFF
--- a/frontend/styles/index.css
+++ b/frontend/styles/index.css
@@ -531,6 +531,106 @@ div.rubric {
   border-radius: 50%;
 }
 
+/* Subscribe form */
+.subscribe-form-wrapper {
+  margin: 2.5rem 0;
+  padding: 1.5rem;
+  border: 1px solid var(--subtle-border);
+  border-radius: 6px;
+  background: var(--card-background);
+}
+
+.subscribe-heading {
+  margin: 0 0 1rem 0;
+  font-weight: 500;
+  color: var(--heading-color);
+}
+
+.embeddable-buttondown-form {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.embeddable-buttondown-form input[type="email"] {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--subtle-border);
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+  color: var(--body-color);
+  background: var(--body-background);
+}
+
+.embeddable-buttondown-form input[type="email"]:focus {
+  outline: none;
+  border-color: var(--action-color);
+}
+
+.embeddable-buttondown-form button[type="submit"] {
+  padding: 0.5rem 1.25rem;
+  background: var(--action-color);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.embeddable-buttondown-form button[type="submit"]:hover {
+  background: var(--action-color-secondary);
+}
+
+.subscribe-attribution {
+  margin: 0.75rem 0 0 0;
+  font-size: 0.8rem;
+  color: var(--muted-text);
+}
+
+.subscribe-attribution a {
+  color: var(--muted-text);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.subscribe-attribution a:hover {
+  border-bottom-color: var(--muted-text);
+}
+
+/* Writing page subscribe CTA */
+.writing-subscribe .subscribe-form-wrapper {
+  max-width: 480px;
+  margin-top: 0;
+  padding: 1.25rem;
+}
+
+.writing-rss-link {
+  margin: 0.75rem 0 0 0;
+  font-size: 0.95rem;
+  color: var(--muted-text);
+}
+
+/* Post footer subscribe — suppress top margin, form sits just below the border */
+.post-footer .subscribe-form-wrapper {
+  margin-top: 0;
+}
+
+.post-footer-link {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.95rem;
+  color: var(--muted-text);
+}
+
+.post-footer-link:last-of-type {
+  margin-bottom: 1.5rem;
+}
+
 .content-body {
   font-size: 1.1rem;
   line-height: 1.7;

--- a/src/_components/subscribe_form.liquid
+++ b/src/_components/subscribe_form.liquid
@@ -1,0 +1,14 @@
+<div class="subscribe-form-wrapper">
+  <p class="subscribe-heading">{{ heading }}</p>
+  <form
+    action="https://buttondown.com/api/emails/embed-subscribe/oscarbarlow"
+    method="post"
+    class="embeddable-buttondown-form"
+  >
+    <input type="email" name="email" id="bd-email" placeholder="your@email.com" aria-label="Email address" required />
+    <button type="submit">Subscribe</button>
+  </form>
+  <p class="subscribe-attribution">
+    <a href="https://buttondown.com/refer/oscarbarlow" target="_blank" rel="noopener noreferrer">Powered by Buttondown</a>
+  </p>
+</div>

--- a/src/_layouts/post.liquid
+++ b/src/_layouts/post.liquid
@@ -19,9 +19,13 @@
             {{ content }}
           </div>
           <footer class="post-footer">
-            <p class="section-links-inline post-links-inline">
-              <a href="{{ '/feed.xml' | relative_url }}" class="section-link">RSS</a>
-              <span class="section-link-divider">|</span>
+            <div class="post-subscribe">
+              {% render 'subscribe_form', heading: 'Enjoyed this? Sign up to get notified of new posts.' %}
+            </div>
+            <p class="post-footer-link">
+              Or subscribe via <a href="{{ '/feed.xml' | relative_url }}" class="section-link">RSS</a>
+            </p>
+            <p class="post-footer-link">
               <a href="{{ '/writing' | relative_url }}" class="section-link">More writing →</a>
             </p>
             <div class="post-signature">

--- a/src/_layouts/posts.liquid
+++ b/src/_layouts/posts.liquid
@@ -10,8 +10,11 @@
       <main class="content-main">
         <div class="page-header">
           {% render 'page_header', title: 'Writing' %}
-          <p class="section-links-inline page-links-inline">
-            <a href="{{ '/feed.xml' | relative_url }}" class="section-link">RSS</a>
+        </div>
+        <div class="writing-subscribe">
+          {% render 'subscribe_form', heading: 'Get new posts by email.' %}
+          <p class="writing-rss-link">
+            Or subscribe via <a href="{{ '/feed.xml' | relative_url }}" class="section-link">RSS</a>
           </p>
         </div>
         <div class="content-body">


### PR DESCRIPTION
Places a subscribe form at the bottom of every post (inside the footer, below the content divider) and a subtle CTA at the top of the Writing page, both linking out to an 'Or subscribe via RSS' fallback.