### PR TITLE
Include all posts in RSS feed

### DIFF
--- a/bridgetown.config.yml
+++ b/bridgetown.config.yml
@@ -33,3 +33,6 @@ strict_front_matter: true
 # timezone: America/Los_Angeles
 # pagination:
 #   enabled: true
+
+feed:
+  posts_limit: 100


### PR DESCRIPTION
bridgetown-feed defaults to 10 items; raise limit to 100.